### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,16 +54,14 @@ RUN dpkg -i nginx_${NGINX_FULL_VERSION}_amd64.deb
 RUN mkdir -p /etc/nginx/rtmp.d && \
     printf "\nrtmp {\n\tinclude /etc/nginx/rtmp.d/*.conf;\n}\n" >> /etc/nginx/nginx.conf
 
-# Install ffmpeg / aac
+# Install ffmpeg / aac / envsubst
 RUN echo 'deb http://www.deb-multimedia.org jessie main non-free' >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y --force-yes deb-multimedia-keyring && \
-    apt-get update && \
-    apt-get install -y \
-        ffmpeg
-
-# Cleanup
-RUN apt-get autoremove -yqq && \
+    apt-get install -y --force-yes \
+        deb-multimedia-keyring \
+        ffmpeg \
+        gettext-base && \
+    apt-get autoremove -yqq && \
     apt-get clean -yqq && \
     rm -rf /usr/src/nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,19 @@ RUN curl -L -o /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key &&
     echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list && \
     echo "deb-src http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
 
+# lua-nginx-module only supports nginx <=1.11.2
 ENV NGINX_VERSION 1.11.2
 ENV NGINX_FULL_VERSION ${NGINX_VERSION}-1~jessie
 ENV RTMP_VERSION 1.2.0
 ENV VOD_VERSION 1.19
+ENV LUA_VERSION 0.10.10
 
 RUN mkdir -p /usr/src/nginx
 WORKDIR /usr/src/nginx
 
 # Download nginx source
 RUN apt-get update && \
+    apt-get install -y libluajit-5.1-dev && \
     apt-get source nginx=${NGINX_FULL_VERSION} && \
     apt-get build-dep -y nginx=${NGINX_FULL_VERSION} && \
     rm -rf /var/lib/apt/lists/*
@@ -29,11 +32,16 @@ RUN curl -L https://github.com/arut/nginx-rtmp-module/archive/v${RTMP_VERSION}.t
 RUN curl -L https://github.com/kaltura/nginx-vod-module/archive/${VOD_VERSION}.tar.gz | tar xz && \
     ln -s nginx-vod-module-${VOD_VERSION} nginx-vod-module
 
+# Download LUA module
+RUN curl -L https://github.com/openresty/lua-nginx-module/archive/v${LUA_VERSION}.tar.gz | tar xz && \
+    ln -s lua-nginx-module-${LUA_VERSION} lua-nginx-module
+
 # Add modules to build nginx debian rules
 ENV RTMP_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-rtmp-module-${RTMP_VERSION}"
 ENV VOD_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-vod-module-${VOD_VERSION}"
 RUN sed -ri "s/--with-ipv6/--with-ipv6 --add-module=${RTMP_MODULE_SOURCE} --add-module=${VOD_MODULE_SOURCE}/" \
         /usr/src/nginx/nginx-${NGINX_VERSION}/debian/rules
+ENV LUA_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/lua-nginx-module"
 
 # Build nginx debian package
 WORKDIR /usr/src/nginx/nginx-${NGINX_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,10 @@ RUN curl -L https://github.com/openresty/lua-nginx-module/archive/v${LUA_VERSION
     ln -s lua-nginx-module-${LUA_VERSION} lua-nginx-module
 
 # Add modules to build nginx debian rules
-ENV RTMP_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-rtmp-module-${RTMP_VERSION}"
-ENV VOD_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-vod-module-${VOD_VERSION}"
-RUN sed -ri "s/--with-ipv6/--with-ipv6 --add-module=${RTMP_MODULE_SOURCE} --add-module=${VOD_MODULE_SOURCE}/" \
-        /usr/src/nginx/nginx-${NGINX_VERSION}/debian/rules
+ENV RTMP_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-rtmp-module"
+ENV VOD_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-vod-module"
 ENV LUA_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/lua-nginx-module"
+RUN sed -i "s#--with-stream_ssl_preread_module#--with-stream_ssl_preread_module --add-module=${RTMP_MODULE_SOURCE} --add-module=${VOD_MODULE_SOURCE} --add-module=${LUA_MODULE_SOURCE}#g" /usr/src/nginx/nginx-${NGINX_VERSION}/debian/rules
 
 # Build nginx debian package
 WORKDIR /usr/src/nginx/nginx-${NGINX_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -L https://github.com/openresty/lua-nginx-module/archive/v${LUA_VERSION
 ENV RTMP_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-rtmp-module"
 ENV VOD_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/nginx-vod-module"
 ENV LUA_MODULE_SOURCE "\\\/usr\\\/src\\\/nginx\\\/nginx-${NGINX_VERSION}\\\/debian\\\/modules\\\/lua-nginx-module"
-RUN sed -i "s#--with-stream_ssl_preread_module#--with-stream_ssl_preread_module --add-module=${RTMP_MODULE_SOURCE} --add-module=${VOD_MODULE_SOURCE} --add-module=${LUA_MODULE_SOURCE}#g" /usr/src/nginx/nginx-${NGINX_VERSION}/debian/rules
+RUN sed -i "s#--with-ipv6#--with-ipv6 --add-module=${RTMP_MODULE_SOURCE} --add-module=${VOD_MODULE_SOURCE} --add-module=${LUA_MODULE_SOURCE}#g" /usr/src/nginx/nginx-${NGINX_VERSION}/debian/rules
 
 # Build nginx debian package
 WORKDIR /usr/src/nginx/nginx-${NGINX_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:stretch
 
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list && \
-    echo "deb-src http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list && \
+    echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list
 
-ENV NGINX_VERSION 1.9.6
-ENV RTMP_VERSION 1.1.7
-ENV VOD_VERSION 1.4
+ENV NGINX_VERSION 1.13
+ENV RTMP_VERSION 1.2.0
+ENV VOD_VERSION 1.19
 
 RUN mkdir -p /usr/src/nginx
 WORKDIR /usr/src/nginx
@@ -14,8 +14,8 @@ WORKDIR /usr/src/nginx
 # Download nginx source
 RUN apt-get update && \
     apt-get install -y ca-certificates dpkg-dev && \
-    apt-get source nginx=${NGINX_VERSION}-1~jessie && \
-    apt-get build-dep -y nginx=${NGINX_VERSION}-1~jessie && \
+    apt-get source nginx=${NGINX_VERSION}-1~stretch && \
+    apt-get build-dep -y nginx=${NGINX_VERSION}-1~stretch && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/nginx/nginx-${NGINX_VERSION}/debian/modules/
@@ -40,14 +40,14 @@ RUN dpkg-buildpackage -b
 
 # Install nginx
 WORKDIR /usr/src/nginx
-RUN dpkg -i nginx_${NGINX_VERSION}-1~jessie_amd64.deb
+RUN dpkg -i nginx_${NGINX_VERSION}-1~stretch_amd64.deb
 
 # Add rtmp config wildcard inclusion
 RUN mkdir -p /etc/nginx/rtmp.d && \
     printf "\nrtmp {\n\tinclude /etc/nginx/rtmp.d/*.conf;\n}\n" >> /etc/nginx/nginx.conf
 
 # Install ffmpeg / aac
-RUN echo 'deb http://www.deb-multimedia.org jessie main non-free' >> /etc/apt/sources.list && \
+RUN echo 'deb http://www.deb-multimedia.org stretch main non-free' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --force-yes deb-multimedia-keyring && \
     apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM buildpack-deps:stretch
 
-RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-RUN echo "deb http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list && \
-    echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list
+RUN curl -L -o /tmp/nginx_signing.key http://nginx.org/keys/nginx_signing.key && \
+    apt-key add /tmp/nginx_signing.key && \
+    echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list && \
+    echo "deb-src http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
 
 ENV NGINX_VERSION 1.13
 ENV RTMP_VERSION 1.2.0


### PR DESCRIPTION
* nginx 1.9.6 -> 1.11.2
* nginx-rtmp-module 1.1.7 -> 1.2.0
* nginx-vod-module 1.4 -> 1.19
* lua-nginx-module 0.10.7 -> 0.10.10

We need to stay on nginx 1.11.2 (1.13.4 latest) as lua-nginx-module isn't compatible with versions below that. We also need to stay on debian jessie as lua-nginx-module does not like openssl 1.1.0 which is shipped with stretch. 

Also skip manually installing ca-certificates dpkg-dev as they are already installed by the base image.